### PR TITLE
use 'cl-lib'

### DIFF
--- a/easy-kill-er.el
+++ b/easy-kill-er.el
@@ -38,6 +38,7 @@
 ;;; Code:
 
 (require 'easy-kill)
+(require 'cl-lib)
 
 (defvar easy-kill-er-history nil)
 
@@ -72,12 +73,12 @@ candidate ARG times."
                  (let ((er/history))
                    (push-mark beg t t)
                    (goto-char end)
-                   (loop repeat arg
+                   (cl-loop repeat arg
                          until (let ((prev (list (point) (mark))))
                                  (or (eq 'early-exit (er--expand-region-1))
                                      (ignore (push prev easy-kill-er-history)))))
                    (list (point) (mark)))
-               (loop repeat (1- (if (zerop arg) (length easy-kill-er-history) arg))
+               (cl-loop repeat (1- (if (zerop arg) (length easy-kill-er-history) arg))
                      do (pop easy-kill-er-history))
                (pop easy-kill-er-history)))))))
 

--- a/extra-things.el
+++ b/extra-things.el
@@ -296,7 +296,7 @@
                           (setq level (1+ level))
                         (setq level (1- level))
                         (if (zerop level)
-                            (return))))
+                            (cl-return))))
              (or (zerop level)
                  (progn
                    (goto-char start)
@@ -313,7 +313,7 @@
                           (setq level (1+ level))
                         (setq level (1- level))
                         (if (zerop level)
-                            (return))))
+                            (cl-return))))
              (or (zerop level)
                  (progn
                    (goto-char start)
@@ -394,7 +394,7 @@
                           (setq level (1+ level))
                         (setq level (1- level))
                         (if (zerop level)
-                            (return))))
+                            (cl-return))))
              (if (< 0 level)
                  (progn
                    (goto-char start)
@@ -416,7 +416,7 @@
                           (setq level (1+ level))
                         (setq level (1- level))
                         (if (zerop level)
-                            (return))))
+                            (cl-return))))
              (if (< 0 level)
                  (progn
                    (goto-char start)

--- a/extra-things.el
+++ b/extra-things.el
@@ -182,10 +182,10 @@
                              ,(if quote
                                   `(if (string= (match-string-no-properties 1) ,quote)
                                        (when (<= start (point))
-                                         (return nil))
+                                         (cl-return nil))
                                      (when (< start (point))
                                        (goto-char start)
-                                       (return nil)))
+                                       (cl-return nil)))
                                 `(when (<= start (point))
                                    (if arg
                                        (let ((qbeg (match-beginning 0))
@@ -195,7 +195,7 @@
                                                (narrow-to-region (1+ qbeg) (1- qend))
                                                (,end-op arg))
                                              (goto-char qend))))
-                                   (return t))))
+                                   (cl-return t))))
                             (t
                              (error "BUG")))))))
 
@@ -211,19 +211,19 @@
                       (cond ((re-search-forward re-nonquoted bound t)
                              (when (< start (point))
                                (goto-char start)
-                               (return nil)))
+                               (cl-return nil)))
                             ((re-search-forward re-quoted nil t)
                              ,(if quote
                                   `(if (string= (match-string-no-properties 1) ,quote)
                                        (when (<= start (point))
                                          (goto-char (match-beginning 0))
-                                         (return t))
+                                         (cl-return t))
                                      (when (< start (point))
                                        (goto-char start)
-                                       (return nil)))
+                                       (cl-return nil)))
                                 `(cond ((= start (point))
                                         (goto-char (match-beginning 0))
-                                        (return t))
+                                        (cl-return t))
                                        ((< start (point))
                                         (if arg
                                             (let ((qbeg (match-beginning 0))
@@ -234,7 +234,7 @@
                                                     (,beginning-op arg))
                                                   (goto-char qbeg)))
                                           (goto-char (match-beginning 0)))
-                                        (return t)))))
+                                        (cl-return t)))))
                             (t
                              (error "BUG")))))))
 


### PR DESCRIPTION
For 'extra-things', the example configuration works for mimunim 'init.el'.

```
(setq make-backup-files nil
      auto-save-default nil)

(add-to-list 'load-path (expand-file-name "~/.emacs.d/straight/repos/easy-kill"))
(add-to-list 'load-path (expand-file-name "~/.emacs.d/straight/repos/easy-kill-extras.el"))

(require 'easy-kill)
(global-set-key [remap kill-ring-save] 'easy-kill)

(require 'easy-kill-extras)
(require 'extra-things)

(add-to-list 'easy-kill-alist '(?\' squoted-string "") t)
(add-to-list 'easy-kill-alist '(?\" dquoted-string "") t)
(add-to-list 'easy-kill-alist '(?\` bquoted-string "") t)
(add-to-list 'easy-kill-alist '(?q  quoted-string "") t)
(add-to-list 'easy-kill-alist '(?Q  quoted-string-universal "") t)
(add-to-list 'easy-kill-alist '(?\) parentheses-pair-content "\n") t)
(add-to-list 'easy-kill-alist '(?\( parentheses-pair "\n") t)
(add-to-list 'easy-kill-alist '(?\] brackets-pair-content "\n") t)
(add-to-list 'easy-kill-alist '(?\[ brackets-pair "\n") t)
(add-to-list 'easy-kill-alist '(?}  curlies-pair-content "\n") t)
(add-to-list 'easy-kill-alist '(?{  curlies-pair "\n") t)
(add-to-list 'easy-kill-alist '(?>  angles-pair-content "\n") t)
(add-to-list 'easy-kill-alist '(?<  angles-pair "\n") t)
(add-to-list 'easy-kill-alist '(?W  WORD " ") t)
```

But for my personal configuration, it throw error:
```
Debugger entered--Lisp error: (invalid-function return)
  return()
  forward-parentheses-pair-content--internal(169)
  forward-parentheses-pair-content(1)
  easy-kill-on-parentheses-pair-content(1)
  easy-kill-thing(parentheses-pair-content 1)
  funcall-interactively(easy-kill-thing parentheses-pair-content 1)
  call-interactively(easy-kill-thing nil nil)
  command-execute(easy-kill-thing)
```